### PR TITLE
from sklearn.externals import joblib doesn't works

### DIFF
--- a/Gender Classification With  Machine Learning/Gender Classification of Names With Machine Learning.ipynb
+++ b/Gender Classification With  Machine Learning/Gender Classification of Names With Machine Learning.ipynb
@@ -2103,7 +2103,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from sklearn.externals import joblib"
+    "import joblib"
    ]
   },
   {


### PR DESCRIPTION
```python
from sklearn.externals import joblib
``` 
doesn't works. Use directly 
```python
import joblib
```